### PR TITLE
_gentoo_packages: remove metadata.xml from completion

### DIFF
--- a/src/_gentoo_packages
+++ b/src/_gentoo_packages
@@ -169,6 +169,7 @@ _gentoo_packages_update_available(){
   else
     compset -P '*/'
     pkg=($repos/$IPREFIX/*(:t))
+    pkg=(${pkg:#metadata.xml})
     _wanted cat_packages expl 'category/package' compadd $pkg
   fi
 }


### PR DESCRIPTION
Currently, when you try to complete cat/pkg, metadata.xml will be shown as one of the completions.

To reproduce: `emerge x11-terms/<TAB>` and you will see metadata.xml in the list.

Remove metadata.xml from the $pkg array after populating it.