### PR TITLE
_gentoolkit: complete `equery keywords` like `eshowkw`

### DIFF
--- a/src/_gentoolkit
+++ b/src/_gentoolkit
@@ -135,6 +135,9 @@ _equery () {
                 '(-F --format)'{-F,--format}'[specify a custom output format]:format template' \
                 ':useflag:_gentoo_packages useflag' && ret=0
               ;;
+            keywords|y)
+              _eshowkw && ret=0
+              ;;
             list|l)
               _arguments \
                 $common_args \


### PR DESCRIPTION
Hi, little fix since `eshowkw` is available through `equery keywords` these days.